### PR TITLE
Improve server-side compilation when there references between files, add minification and use lesscpy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ build/
 develop-eggs/
 downloads/
 eggs/
+extras/
 fake-eggs/
 parts/
 dist/

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,6 +4,10 @@ Changelog
 1.4.dev0 (unreleased)
 ---------------------
 
+- Use python package lesscpy directly instead of calling a script (#8).
+  This allows to get rid of Node.js in buildout for server-side compiling.
+  [laulaz]
+
 - Add (optional) minification of LESS files.
   Code is based on https://github.com/collective/collective.lesscss/pull/9 but
   uses lessc script directly (instead of cleancss) with compress option.

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,7 +4,12 @@ Changelog
 1.4.dev0 (unreleased)
 ---------------------
 
-- Improve server-side compilation when there references between files.
+- Add (optional) minification of LESS files.
+  Code is based on https://github.com/collective/collective.lesscss/pull/9 but
+  uses lessc script directly (instead of cleancss) with compress option.
+  [laulaz]
+
+- Improve server-side compilation when there are references between files.
   We need to compile the resources all together because otherwise the compiler
   will fail on unknown variables references between files.
   [laulaz]

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,7 +1,7 @@
 Changelog
 =========
 
-1.4.dev0 (unreleased)
+2.0.dev0 (unreleased)
 ---------------------
 
 - Use python package lesscpy directly instead of calling a script (#8).

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,6 +4,11 @@ Changelog
 1.4.dev0 (unreleased)
 ---------------------
 
+- Improve server-side compilation when there references between files.
+  We need to compile the resources all together because otherwise the compiler
+  will fail on unknown variables references between files.
+  [laulaz]
+
 - Added Spanish translation
   [macagua]
 

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -1,3 +1,4 @@
 Victor Fernandez de Alba [sneridagh], Author
 Sebastian Jordan [seppeljordan]
 Leonardo J. Caballero G. [macagua]
+Laurent Lasudry [laulaz]

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -1,4 +1,7 @@
-Victor Fernandez de Alba [sneridagh], Author
-Sebastian Jordan [seppeljordan]
-Leonardo J. Caballero G. [macagua]
-Laurent Lasudry [laulaz]
+Contributors
+============
+
+- Victor Fernandez de Alba [sneridagh], Author
+- Sebastian Jordan [seppeljordan]
+- Leonardo J. Caballero G. [macagua]
+- Laurent Lasudry [laulaz]

--- a/README.rst
+++ b/README.rst
@@ -8,7 +8,7 @@ This package allow theme developers to add LESS stylesheets into a Plone site.
 LESS
 ====
 
-LESS extends CSS with dynamic behavior such as variables, mixins, operations and functions. LESS runs on both the client-side (Chrome, Safari, Firefox) and server-side, with Node.js and Rhino.
+LESS extends CSS with dynamic behavior such as variables, mixins, operations and functions. LESS runs on both the client-side (Chrome, Safari, Firefox) and server-side.
 
 You can find more information about LESS at http://lesscss.org/
 
@@ -34,7 +34,7 @@ This package is intended to be used in conjunction with an user defined Plone Th
 Control Panel
 =============
 
-You can manage the way the LESS resources compile by accessing the LESS resources configlet located at the site setup. By default, client-side LESS resources compile mode is enabled.
+You can manage the way the LESS resources compile by accessing the LESS resources configlet located at the site setup. By default, client-side LESS resources compile mode and minification are enabled.
 
 Client side compiling
 =====================
@@ -50,24 +50,7 @@ collective.lesscss will use the standard method for compiling client-side by usi
 Server side compiling
 =====================
 
-Server-side compiled LESS resources are recommended in production mode. By unsetting this option, the site will server-side compile them into CSS resources and enable a volatile cache on them. Node.js is used for server side compiling, so you should have a Node.js installed in your system and less package installed as well. It's recommended to let buildout handle this for you::
-
-    [buildout]
-    parts = ...
-            nodejs
-            ...
-
-    ...
-
-    [nodejs]
-    recipe = gp.recipe.node
-    url = http://nodejs.org/dist/v0.10.29/node-v0.10.29.tar.gz
-    npms = less
-    scripts = lessc
-
-This will download and compile Node.js and less extension. The *lessc* executable will be available at *bin* directory of your buildout. Please, review https://github.com/collective/collective.lesscss/blob/master/buildout.cfg for more references.
-
-In case you already have Node.js and less extension in your system it's required for you to create a symbolic link of *lessc* executable at *bin* directory of your buildout.
+Server-side compiled LESS resources are recommended in production mode. By unsetting this option, the site will server-side compile them into CSS resources and enable a volatile cache on them. 
 
 IMPORTANT NOTE: Server-side compiling requires to have declared the resources via plone.resource package in your theme package! Example::
 

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -3,7 +3,6 @@ parts =
     test
     instance
     omelette
-    nodejs
 
 extends =
     http://dist.plone.org/release/4.1-latest/versions.cfg
@@ -35,12 +34,6 @@ eggs =
     example.bootstrap
     ${buildout:package-name}
 environment-vars = zope_i18n_compile_mo_files true
-
-[nodejs]
-recipe = gp.recipe.node
-url = http://nodejs.org/dist/v0.10.26/node-v0.10.26.tar.gz
-npms = less
-scripts = lessc
 
 [test]
 recipe = zc.recipe.testrunner

--- a/setup.py
+++ b/setup.py
@@ -5,9 +5,6 @@ version = '1.4.dev0'
 long_description = (
     open('README.rst').read()
     + '\n' +
-    'Contributors\n'
-    '============\n'
-    + '\n' +
     open('CONTRIBUTORS.txt').read()
     + '\n' +
     open('CHANGES.txt').read()

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,4 @@
 from setuptools import setup, find_packages
-import os
 
 version = '1.4.dev0'
 
@@ -37,7 +36,8 @@ setup(name='collective.lesscss',
       install_requires=[
           'setuptools',
           'Products.ResourceRegistries',
-          'plone.resource'
+          'plone.resource',
+          'lesscpy',
           # -*- Extra requirements: -*-
       ],
       extras_require={'test': ['plone.app.testing']},

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-version = '1.4.dev0'
+version = '2.0.dev0'
 
 long_description = (
     open('README.rst').read()

--- a/src/collective/lesscss/browser/compiledcss.py
+++ b/src/collective/lesscss/browser/compiledcss.py
@@ -40,8 +40,12 @@ class compiledCSSView(BrowserView):
         inline_code = portal_less.getInlineResource(item_id, self.context)
         return inline_code
 
-    @ram.cache(render_cachekey)
     def __call__(self):
+        self.request.response.setHeader('Content-Type', 'text/css')
+        return self.get_compiled_less_ressources()
+
+    @ram.cache(render_cachekey)
+    def get_compiled_less_ressources(self):
         portal_less = self.portal_less()
 
         less_resources = portal_less.getEvaluatedResources(self.context)
@@ -65,7 +69,6 @@ class compiledCSSView(BrowserView):
         if mustMinify:
             self.logger.info("Resources have been minified.")
 
-        self.request.response.setHeader('Content-Type', 'text/css')
         return compiled_css
 
     def compile_less_code(self, less_code, minify=False):

--- a/src/collective/lesscss/browser/compiledcss.py
+++ b/src/collective/lesscss/browser/compiledcss.py
@@ -2,11 +2,8 @@ import os
 import subprocess
 from Products.Five.browser import BrowserView
 from Products.CMFCore.utils import getToolByName
-from plone.resource.interfaces import IResourceDirectory
-from zope.component import getUtility
 from plone.memoize import ram
 import logging
-import re
 
 
 def render_cachekey(method, self):
@@ -25,7 +22,6 @@ class compiledCSSView(BrowserView):
 
     def portal_less(self):
         return getToolByName(self.context, 'portal_less')
-                    
 
     def getInlineLess(self, item_id):
         """ Get the less code of a registered resource as a string

--- a/src/collective/lesscss/browser/compiledcss.py
+++ b/src/collective/lesscss/browser/compiledcss.py
@@ -66,7 +66,7 @@ class compiledCSSView(BrowserView):
 
         for res_id in less_resources_ids:
             self.logger.info("The resource %s has been server-side compiled." % res_id)
-        if mustMinify:
+        if mustMinify and less_resources_ids:
             self.logger.info("Resources have been minified.")
 
         return compiled_css

--- a/src/collective/lesscss/browser/compiledcss.py
+++ b/src/collective/lesscss/browser/compiledcss.py
@@ -54,7 +54,7 @@ class compiledCSSView(BrowserView):
             results.append(resource_inline)
             results.append('\n/*    End  %s    */\n' % res_id)
 
-        mustMinify = self.useCleanCss()
+        mustMinify = self.shouldMinify()
         compiled_css = self.compile_less_code(
             ''.join(results),
             mustMinify
@@ -85,7 +85,7 @@ class compiledCSSView(BrowserView):
             self.logger.error(e)
         return output
 
-    def useCleanCss(self):
+    def shouldMinify(self):
         registry = queryUtility(IRegistry)
         settings = registry.forInterface(ILESSCSSControlPanel, check=False)
         return settings.use_clean_css

--- a/src/collective/lesscss/browser/controlpanel.py
+++ b/src/collective/lesscss/browser/controlpanel.py
@@ -37,10 +37,10 @@ class ILESSCSSControlPanel(Interface):
 
     use_clean_css = schema.Bool(
         title=_(u'label_use_clean_css',
-                default=u'Enable css compression using clean'),
+                default=u'Enable CSS compression'),
         description=_(u'description_use_clean_css',
-                      default=u"This setting controls whether the compiled css"
-                              u" code will be compressed (minified)"),
+                      default=u"This setting controls whether the compiled CSS"
+                              u" code will be compressed (minified)."),
         default=True
     )
 

--- a/src/collective/lesscss/browser/controlpanel.py
+++ b/src/collective/lesscss/browser/controlpanel.py
@@ -40,7 +40,7 @@ class ILESSCSSControlPanel(Interface):
                 default=u'Enable css compression using clean'),
         description=_(u'description_use_clean_css',
                       default=u"This setting controls whether the compiled css"
-                              u" code will be compressed using clean-css"),
+                              u" code will be compressed (minified)"),
         default=True
     )
 
@@ -66,7 +66,7 @@ class LESSCSSEditForm(controlpanel.RegistryEditForm):
         if errors:
             self.status = self.formErrorsMessage
             return
-        changes = self.applyChanges(data)
+        self.applyChanges(data)
         IStatusMessage(self.request).addStatusMessage(_(u"Changes saved"),
                                                       "info")
         self.context.REQUEST.RESPONSE.redirect("@@lesscss-controlpanel")

--- a/src/collective/lesscss/browser/controlpanel.py
+++ b/src/collective/lesscss/browser/controlpanel.py
@@ -20,15 +20,29 @@ class ILESSCSSControlPanel(Interface):
     """
 
     enable_less_stylesheets = schema.Bool(
-        title=_(u'label_enable_less_stylesheets', default=u'Enable client-side compiling LESS stylesheets'),
+        title=_(u'label_enable_less_stylesheets',
+                default=u'Enable client-side compiling LESS stylesheets'),
         description=_(u'help_enable_less_stylesheets',
-                        default=u"This setting will control the way LESS stylesheets are compiled for this site. "
-                                u"Client-side compiling is intended to use while in (theme) development mode. "
-                                u"Server-side compiled LESS resources are recommended in production mode. "
-                                u"By unsetting this option, this site will server-side compile them into CSS "
-                                u"resources and enable cache on them."),
+                      default=u"This setting will control the way LESS "
+                              u"stylesheets are compiled for this site. "
+                              u"Client-side compiling is intended to use "
+                              u"while in (theme) development mode. "
+                              u"Server-side compiled LESS resources are "
+                              u"recommended in production mode. "
+                              u"By unsetting this option, this site will "
+                              u"server-side compile them into CSS "
+                              u"resources and enable cache on them."),
         default=True
         )
+
+    use_clean_css = schema.Bool(
+        title=_(u'label_use_clean_css',
+                default=u'Enable css compression using clean'),
+        description=_(u'description_use_clean_css',
+                      default=u"This setting controls whether the compiled css"
+                              u" code will be compressed using clean-css"),
+        default=True
+    )
 
 
 class LESSCSSEditForm(controlpanel.RegistryEditForm):

--- a/src/collective/lesscss/browser/interfaces.py
+++ b/src/collective/lesscss/browser/interfaces.py
@@ -1,4 +1,4 @@
-from zope.interface import Interface, Attribute
+from zope.interface import Interface
 
 
 class IScriptsView(Interface):
@@ -11,6 +11,7 @@ class IStylesView(Interface):
 
     def styles():
         """ Returns a list of dicts with information for style rendering. """
+
 
 class IKSSView(Interface):
 

--- a/src/collective/lesscss/browser/less.py
+++ b/src/collective/lesscss/browser/less.py
@@ -51,7 +51,8 @@ class LESSStylesView(BrowserView):
                         'conditionalcomment': style.getConditionalcomment(),
                         'content': content}
             else:
-                raise ValueError("Unkown rendering method '%s' for style '%s'" % (rendering, style.getId()))
+                raise ValueError("Unkown rendering method '%s' for style '%s'"
+                                 % (rendering, style.getId()))
             result.append(data)
         return result
 
@@ -61,5 +62,6 @@ class LESSStylesView(BrowserView):
         return settings.enable_less_stylesheets
 
     def compiledCSSURL(self):
-        portal_state = getMultiAdapter((self.context, self.request), name=u'plone_portal_state')
+        portal_state = getMultiAdapter((self.context, self.request),
+                                       name=u'plone_portal_state')
         return "%s/compiled_styles.css" % portal_state.portal_url()

--- a/src/collective/lesscss/testing.py
+++ b/src/collective/lesscss/testing.py
@@ -3,7 +3,6 @@ from plone.app.testing import PloneSandboxLayer
 from plone.app.testing import IntegrationTesting
 from plone.app.testing import FunctionalTesting
 from plone.app.testing import applyProfile
-from plone.testing import z2
 
 from zope.configuration import xmlconfig
 

--- a/src/collective/lesscss/tests/testLESSRegistry.py
+++ b/src/collective/lesscss/tests/testLESSRegistry.py
@@ -1,5 +1,3 @@
-import unittest2 as unittest
-from plone.app.testing import login
 from plone.app.testing import setRoles
 from plone.app.testing import TEST_USER_ID
 


### PR DESCRIPTION
We need to compile the resources all together because otherwise the compiler will fail on unknown variables references between files.

Optional minification has also been added based on #9 but using `lessc`script with `compress`option directly.

`Node.js` and `lessc` script are no longer needed for server-side compilation : `lesscpy` is now used directly.