### PR TITLE
Allow browser to cache compiled CSS

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,6 +4,10 @@ Changelog
 2.0.3 (unreleased)
 ------------------
 
+- Allow browser to cache compiled CSS (compiled_styles.css) while portal_less is
+  not in debug mode
+  [laulaz]
+
 - Updated Spanish translation
   [macagua]
 

--- a/src/collective/lesscss/browser/compiledcss.py
+++ b/src/collective/lesscss/browser/compiledcss.py
@@ -47,6 +47,11 @@ class compiledCSSView(BrowserView):
 
     def __call__(self):
         self.request.response.setHeader('Content-Type', 'text/css')
+        portal_less = api.portal.get_tool('portal_less')
+        if portal_less.getDebugMode():
+            self.request.response.setHeader('Cache-Control', 'no-cache')
+        else:
+            self.request.response.setHeader('Cache-Control', 'public, max-age=31536000')
         return self.get_compiled_less_ressources()
 
     @ram.cache(render_cachekey)


### PR DESCRIPTION
compiled_styles.css is cached while portal_less is not in debug mode